### PR TITLE
Alfredbrannare/exercise3

### DIFF
--- a/src/main/java/org/example/App.java
+++ b/src/main/java/org/example/App.java
@@ -1,7 +1,5 @@
 package org.example;
 
 public class App {
-    public static void main(String[] args) {
-        System.out.println("Hello There!");
-    }
+
 }

--- a/src/main/java/org/example/entities/Category.java
+++ b/src/main/java/org/example/entities/Category.java
@@ -1,0 +1,5 @@
+package org.example.entities;
+
+public enum Category {
+    GENERAL,
+}

--- a/src/main/java/org/example/entities/Category.java
+++ b/src/main/java/org/example/entities/Category.java
@@ -2,4 +2,7 @@ package org.example.entities;
 
 public enum Category {
     GENERAL,
+    FOOD,
+    CLOTHING,
+    ELECTRONICS,
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -2,12 +2,23 @@ package org.example.entities;
 
 public class Product {
     private int id;
+    private String name;
 
     public Product(int id) {
         this.id = id;
+        this.name = "";
+    }
+
+    public Product(int id, String name) {
+        this.id = id;
+        this.name = name;
     }
 
     public int getId() {
         return this.id;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -1,14 +1,14 @@
 package org.example.entities;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class Product {
     private final String id;
     private final String name;
     private final Category category;
     private final int rating;
-    private final LocalDate createdDate;
-    private final LocalDate modifiedDate;
+    private final LocalDateTime createdDate;
+    private final LocalDateTime modifiedDate;
 
     // Constructors
     public Product(String id) {
@@ -24,7 +24,7 @@ public class Product {
     }
 
     public Product(String id, String name, Category category, int rating) {
-        LocalDate now = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
         this.id = id;
         this.name = name;
         this.category = category;
@@ -33,7 +33,7 @@ public class Product {
         this.modifiedDate = now;
     }
 
-    private Product(String id, String name, Category category, int rating, LocalDate createdDate, LocalDate modifiedDate) {
+    private Product(String id, String name, Category category, int rating, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.name = name;
         this.category = category;
@@ -59,16 +59,16 @@ public class Product {
         return this.rating;
     }
 
-    public LocalDate getCreatedDate() {
+    public LocalDateTime getCreatedDate() {
         return this.createdDate;
     }
 
-    public LocalDate getModifiedDate() {
+    public LocalDateTime getModifiedDate() {
         return this.modifiedDate;
     }
 
     // Methods
     public Product update(String name, Category category, int rating) {
-        return new Product(this.id, name, category, rating, this.createdDate, LocalDate.now());
+        return new Product(this.id, name, category, rating, this.createdDate, LocalDateTime.now());
     }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -1,0 +1,5 @@
+package org.example.entities;
+
+public class Product {
+
+}

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -4,6 +4,7 @@ public class Product {
     private final int id;
     private final String name;
     private final Category category;
+    private final double rating;
 
     // Constructors
     public Product(int id) {
@@ -15,9 +16,14 @@ public class Product {
     }
 
     public Product(int id, String name, Category category) {
+        this(id, name, category, 0.0);
+    }
+
+    public Product(int id, String name, Category category, double rating) {
         this.id = id;
         this.name = name;
         this.category = category;
+        this.rating = rating;
     }
 
     // Getters
@@ -31,5 +37,9 @@ public class Product {
 
     public Category getCategory() {
         return this.category;
+    }
+
+    public double getRating() {
+        return this.rating;
     }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -1,5 +1,13 @@
 package org.example.entities;
 
 public class Product {
+    private int id;
 
+    public Product(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return this.id;
+    }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -8,7 +8,7 @@ public class Product {
     private final Category category;
     private final int rating;
     private final LocalDate createdDate;
-    private LocalDate modifiedDate;
+    private final LocalDate modifiedDate;
 
     // Constructors
     public Product(int id) {
@@ -24,11 +24,22 @@ public class Product {
     }
 
     public Product(int id, String name, Category category, int rating) {
+        LocalDate now = LocalDate.now();
         this.id = id;
         this.name = name;
         this.category = category;
         this.rating = rating;
-        this.createdDate = LocalDate.now();
+        this.createdDate = now;
+        this.modifiedDate = now;
+    }
+
+    private Product(int id, String name, Category category, int rating, LocalDate createdDate, LocalDate modifiedDate) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.rating = rating;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
     }
 
     // Getters
@@ -56,12 +67,8 @@ public class Product {
         return this.modifiedDate;
     }
 
-    // Setters
-    private void setModifiedDate() {
-        this.modifiedDate = LocalDate.now();
-    }
-
-    public void setName(String notebook) {
-        setModifiedDate();
+    // Methods
+    public Product update(String name, Category category, int rating) {
+        return new Product(this.id, name, category, rating, this.createdDate, LocalDate.now());
     }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -6,8 +6,9 @@ public class Product {
     private final int id;
     private final String name;
     private final Category category;
-    private final double rating;
+    private final int rating;
     private final LocalDate createdDate;
+    private LocalDate modifiedDate;
 
     // Constructors
     public Product(int id) {
@@ -19,10 +20,10 @@ public class Product {
     }
 
     public Product(int id, String name, Category category) {
-        this(id, name, category, 0.0);
+        this(id, name, category, 0);
     }
 
-    public Product(int id, String name, Category category, double rating) {
+    public Product(int id, String name, Category category, int rating) {
         this.id = id;
         this.name = name;
         this.category = category;
@@ -43,7 +44,7 @@ public class Product {
         return this.category;
     }
 
-    public double getRating() {
+    public int getRating() {
         return this.rating;
     }
 
@@ -51,4 +52,16 @@ public class Product {
         return this.createdDate;
     }
 
+    public LocalDate getModifiedDate() {
+        return this.modifiedDate;
+    }
+
+    // Setters
+    private void setModifiedDate() {
+        this.modifiedDate = LocalDate.now();
+    }
+
+    public void setName(String notebook) {
+        setModifiedDate();
+    }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -3,7 +3,7 @@ package org.example.entities;
 import java.time.LocalDate;
 
 public class Product {
-    private final int id;
+    private final String id;
     private final String name;
     private final Category category;
     private final int rating;
@@ -11,19 +11,19 @@ public class Product {
     private final LocalDate modifiedDate;
 
     // Constructors
-    public Product(int id) {
+    public Product(String id) {
         this(id, "");
     }
 
-    public Product(int id, String name) {
+    public Product(String id, String name) {
         this(id, name, Category.GENERAL);
     }
 
-    public Product(int id, String name, Category category) {
+    public Product(String id, String name, Category category) {
         this(id, name, category, 0);
     }
 
-    public Product(int id, String name, Category category, int rating) {
+    public Product(String id, String name, Category category, int rating) {
         LocalDate now = LocalDate.now();
         this.id = id;
         this.name = name;
@@ -33,7 +33,7 @@ public class Product {
         this.modifiedDate = now;
     }
 
-    private Product(int id, String name, Category category, int rating, LocalDate createdDate, LocalDate modifiedDate) {
+    private Product(String id, String name, Category category, int rating, LocalDate createdDate, LocalDate modifiedDate) {
         this.id = id;
         this.name = name;
         this.category = category;
@@ -43,7 +43,7 @@ public class Product {
     }
 
     // Getters
-    public int getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -1,24 +1,35 @@
 package org.example.entities;
 
 public class Product {
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
+    private final Category category;
 
+    // Constructors
     public Product(int id) {
-        this.id = id;
-        this.name = "";
+        this(id, "");
     }
 
     public Product(int id, String name) {
-        this.id = id;
-        this.name = name;
+        this(id, name, Category.GENERAL);
     }
 
+    public Product(int id, String name, Category category) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+    }
+
+    // Getters
     public int getId() {
         return this.id;
     }
 
     public String getName() {
         return this.name;
+    }
+
+    public Category getCategory() {
+        return this.category;
     }
 }

--- a/src/main/java/org/example/entities/Product.java
+++ b/src/main/java/org/example/entities/Product.java
@@ -1,10 +1,13 @@
 package org.example.entities;
 
+import java.time.LocalDate;
+
 public class Product {
     private final int id;
     private final String name;
     private final Category category;
     private final double rating;
+    private final LocalDate createdDate;
 
     // Constructors
     public Product(int id) {
@@ -24,6 +27,7 @@ public class Product {
         this.name = name;
         this.category = category;
         this.rating = rating;
+        this.createdDate = LocalDate.now();
     }
 
     // Getters
@@ -42,4 +46,9 @@ public class Product {
     public double getRating() {
         return this.rating;
     }
+
+    public LocalDate getCreatedDate() {
+        return this.createdDate;
+    }
+
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -4,6 +4,7 @@ import org.example.entities.Product;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class Warehouse {
     private final List<Product> products = new ArrayList<>();
@@ -19,6 +20,19 @@ public class Warehouse {
             throw new IllegalArgumentException("Product name cannot be null or blank");
         }
         products.add(product);
+    }
+
+    public void updateProduct(Product product) {
+        if (product == null || product.getName().isBlank()) {
+            throw new IllegalArgumentException("Product name cannot be null or blank");
+        }
+
+        int index = IntStream.range(0, products.size())
+                .filter(i -> products.get(i).getId() == product.getId())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+
+        products.set(index, product);
     }
 
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -1,0 +1,22 @@
+package org.example.service;
+
+import org.example.entities.Product;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Warehouse {
+    private final List<Product> products = new ArrayList<>();
+
+    // Getters
+    public List<Product> getAllProducts() {
+        return new ArrayList<>(products);
+    }
+
+    // Methods
+    public void addProduct(Product product) {
+        products.add(product);
+    }
+
+
+}

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -1,5 +1,6 @@
 package org.example.service;
 
+import org.example.entities.Category;
 import org.example.entities.Product;
 
 import java.util.ArrayList;
@@ -42,4 +43,10 @@ public class Warehouse {
         products.set(index, product);
     }
 
+    public List<Product> getProductsByCategorySorted(Category category) {
+        return products.stream()
+                .filter(p -> p.getCategory() == category)
+                .sorted((p1, p2) -> p1.getName().compareToIgnoreCase(p2.getName()))
+                .toList();
+    }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class Warehouse {
@@ -85,5 +86,12 @@ public class Warehouse {
         return products.stream()
                 .filter(p -> p.getModifiedDate().isAfter(p.getCreatedDate()))
                 .toList();
+    }
+
+    public List<Category> getCategoriesWithProducts() {
+        return products.stream()
+                .map(Product::getCategory)
+                .distinct()
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -15,8 +15,10 @@ public class Warehouse {
 
     // Methods
     public void addProduct(Product product) {
+        if (product == null || product.getName().isBlank()) {
+            throw new IllegalArgumentException("Product name cannot be null or blank");
+        }
         products.add(product);
     }
-
 
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -49,6 +49,10 @@ public class Warehouse {
     }
 
     public List<Product> getProductsByCategorySorted(Category category) {
+        if (category == null) {
+            throw new IllegalArgumentException("Category cannot be null");
+        }
+
         return products.stream()
                 .filter(p -> p.getCategory() == category)
                 .sorted((p1, p2) -> p1.getName().compareToIgnoreCase(p2.getName()))

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -14,6 +14,13 @@ public class Warehouse {
         return new ArrayList<>(products);
     }
 
+    public Product getProductById(int id) {
+        return products.stream()
+                .filter(p -> p.getId() == id)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+    }
+
     // Methods
     public void addProduct(Product product) {
         if (product == null || product.getName().isBlank()) {

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -14,11 +14,11 @@ public class Warehouse {
         return new ArrayList<>(products);
     }
 
-    public Product getProductById(int id) {
-        return products.stream()
-                .filter(p -> p.getId() == id)
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+    public Product getProductById(String id) {
+      return products.stream()
+              .filter(p -> p.getId().equals(id))
+              .findFirst()
+              .orElseThrow(() -> new IllegalArgumentException("Product not found"));
     }
 
     // Methods

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -77,4 +77,10 @@ public class Warehouse {
                 .filter(p -> p.getCreatedDate().isAfter(date) || p.getCreatedDate().isEqual(date))
                 .toList();
     }
+
+    public List<Product> getModifiedProducts() {
+        return products.stream()
+                .filter(p -> p.getModifiedDate().isAfter(p.getCreatedDate()))
+                .toList();
+    }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -35,17 +35,26 @@ public class Warehouse {
         products.add(product);
     }
 
-    public void updateProduct(Product product) {
-        if (product == null || product.getName().isBlank()) {
+    public void updateProduct(String id, String name, Category category, int rating) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Product id cannot be null or blank");
+        }
+        if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Product name cannot be null or blank");
+        }
+        if (category == null) {
+            throw new IllegalArgumentException("Category cannot be null");
         }
 
         int index = IntStream.range(0, products.size())
-                .filter(i -> products.get(i).getId() == product.getId())
+                .filter(i -> products.get(i).getId().equals(id))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Product not found"));
 
-        products.set(index, product);
+        Product existingProduct = products.get(index);
+        Product updatedProduct = existingProduct.update(name, category, rating);
+
+        products.set(index, updatedProduct);
     }
 
     public List<Product> getProductsByCategorySorted(Category category) {

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -4,9 +4,7 @@ import org.example.entities.Category;
 import org.example.entities.Product;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -104,4 +102,13 @@ public class Warehouse {
                 .filter(p -> p.getCategory() == category)
                 .count();
     }
+
+    public Map<Character, Integer> getProductInitialsMap() {
+        return products.stream()
+                .map(Product::getName)
+                .map(name -> name.charAt(0))
+                .collect(Collectors.toMap(name -> name, name -> 1, Integer::sum));
+    }
+
+
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -111,4 +111,15 @@ public class Warehouse {
     }
 
 
+    public List<Product> getTopRatedProductsThisMonth() {
+        int maxRating = products.stream()
+                .filter(p -> p.getCreatedDate().getMonth().equals(LocalDateTime.now().getMonth()))
+                .map(Product::getRating).max(Integer::compareTo).orElse(0);
+
+        return products.stream()
+                .filter(p -> p.getCreatedDate().getMonth().equals(LocalDateTime.now().getMonth()))
+                .filter(p -> p.getRating() == maxRating)
+                .sorted((p1, p2) -> p2.getCreatedDate().compareTo(p1.getCreatedDate()))
+                .toList();
+    }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -45,6 +45,9 @@ public class Warehouse {
         if (category == null) {
             throw new IllegalArgumentException("Category cannot be null");
         }
+        if (rating < 1 || rating > 10){
+            throw new IllegalArgumentException("Rating must be between 1 and 10");
+        }
 
         int index = IntStream.range(0, products.size())
                 .filter(i -> products.get(i).getId().equals(id))

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -94,4 +94,14 @@ public class Warehouse {
                 .distinct()
                 .collect(Collectors.toList());
     }
+
+    public long countProductsInCategory(Category category) {
+        if (category == null) {
+            throw new IllegalArgumentException("Category cannot be null");
+        }
+
+        return products.stream()
+                .filter(p -> p.getCategory() == category)
+                .count();
+    }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -3,7 +3,7 @@ package org.example.service;
 import org.example.entities.Category;
 import org.example.entities.Product;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -68,7 +68,7 @@ public class Warehouse {
                 .toList();
     }
 
-    public List<Product> getProductsCreatedAfter(LocalDate date) {
+    public List<Product> getProductsCreatedAfter(LocalDateTime date) {
         if (date == null) {
             throw new IllegalArgumentException("Date cannot be null");
         }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -3,6 +3,7 @@ package org.example.service;
 import org.example.entities.Category;
 import org.example.entities.Product;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -47,6 +48,16 @@ public class Warehouse {
         return products.stream()
                 .filter(p -> p.getCategory() == category)
                 .sorted((p1, p2) -> p1.getName().compareToIgnoreCase(p2.getName()))
+                .toList();
+    }
+
+    public List<Product> getProductsCreatedAfter(LocalDate date) {
+        if (date == null) {
+            throw new IllegalArgumentException("Date cannot be null");
+        }
+
+        return products.stream()
+                .filter(p -> p.getCreatedDate().isAfter(date) || p.getCreatedDate().isEqual(date))
                 .toList();
     }
 }

--- a/src/main/java/org/example/service/Warehouse.java
+++ b/src/main/java/org/example/service/Warehouse.java
@@ -6,6 +6,7 @@ import org.example.entities.Product;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 public class Warehouse {
@@ -16,11 +17,14 @@ public class Warehouse {
         return new ArrayList<>(products);
     }
 
-    public Product getProductById(String id) {
-      return products.stream()
-              .filter(p -> p.getId().equals(id))
-              .findFirst()
-              .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+    public Optional<Product> getProductById(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Product id cannot be null or blank");
+        }
+
+        return products.stream()
+                .filter(p -> p.getId().equals(id))
+                .findFirst();
     }
 
     // Methods

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -30,4 +30,11 @@ public class ProductTest {
         Product product = new Product(1, "Laptop", Category.GENERAL);
         assertThat(product.getCategory()).isEqualTo(Category.GENERAL);
     }
+
+    @Test
+    @DisplayName("Can create a Product with a rating")
+    public void canCreateProductWithRating() {
+        Product product = new Product(1, "Laptop", Category.GENERAL, 1.5);
+        assertThat(product.getRating()).isEqualTo(1.5);
+    }
 }

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -57,6 +57,7 @@ public class ProductTest {
     @DisplayName("Can update a Product's modified date when name is changed")
     public void canCreateProductWithModifiedDate() {
         Product product;
+        Product updated;
 
         try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
             LocalDate currentDate = LocalDate.of(2025, 1, 1);
@@ -65,11 +66,12 @@ public class ProductTest {
         }
 
         try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
-            LocalDate currentDate = LocalDate.of(2025, 1, 1);
-            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
-            product.setName("Notebook");
+            LocalDate updateDate = LocalDate.of(2025, 1, 5);
+            mockedStatic.when(LocalDate::now).thenReturn(updateDate);
+            updated = product.update("Notebook", Category.GENERAL, 2);
 
-            assertThat(product.getModifiedDate()).isEqualTo(currentDate);
+            assertThat(updated.getModifiedDate()).isEqualTo(updateDate);
+            assertThat(product.getModifiedDate()).isNotEqualTo(updateDate);
         }
     }
 

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,8 +37,8 @@ public class ProductTest {
     @Test
     @DisplayName("Can create a Product with a rating")
     public void canCreateProductWithRating() {
-        Product product = new Product(1, "Laptop", Category.GENERAL, 1.5);
-        assertThat(product.getRating()).isEqualTo(1.5);
+        Product product = new Product(1, "Laptop", Category.GENERAL, 1);
+        assertThat(product.getRating()).isEqualTo(1);
     }
 
     @Test
@@ -47,8 +48,29 @@ public class ProductTest {
             LocalDate currentDate = LocalDate.of(2025, 1, 1);
             mockedStatic.when(LocalDate::now).thenReturn(currentDate);
 
-            Product product = new Product(1, "Laptop", Category.GENERAL, 1.5);
+            Product product = new Product(1, "Laptop", Category.GENERAL, 1);
             assertThat(product.getCreatedDate()).isEqualTo(currentDate);
         }
     }
+
+    @Test
+    @DisplayName("Can update a Product's modified date when name is changed")
+    public void canCreateProductWithModifiedDate() {
+        Product product;
+
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDate currentDate = LocalDate.of(2025, 1, 1);
+            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
+            product = new Product(1, "Laptop", Category.GENERAL, 1);
+        }
+
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDate currentDate = LocalDate.of(2025, 1, 1);
+            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
+            product.setName("Notebook");
+
+            assertThat(product.getModifiedDate()).isEqualTo(currentDate);
+        }
+    }
+
 }

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -1,5 +1,6 @@
 package org.example;
 
+import org.example.entities.Category;
 import org.example.entities.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,7 @@ public class ProductTest {
 
     @Test
     @DisplayName("Can create a Product with a unique ID")
-    public void canCreateProductWithId(){
+    public void canCreateProductWithId() {
         Product product = new Product(1);
         assertThat(product.getId()).isEqualTo(1);
     }
@@ -18,8 +19,15 @@ public class ProductTest {
 
     @Test
     @DisplayName("Can create a Product with a name")
-    public void canCreateProductWithName(){
+    public void canCreateProductWithName() {
         Product product = new Product(1, "Laptop");
         assertThat(product.getName()).isEqualTo("Laptop");
+    }
+
+    @Test
+    @DisplayName("Can create a Product with a category")
+    public void canCreateProductWithCategory() {
+        Product product = new Product(1, "Laptop", Category.GENERAL);
+        assertThat(product.getCategory()).isEqualTo(Category.GENERAL);
     }
 }

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductTest {
-    @Test
-    @DisplayName("Can create a valid Product instance")
-    public void canCreateProduct() {
-        Product product = new Product();
 
-        assertThat(product).isNotNull();
+    @Test
+    @DisplayName("Can create a Product with a unique ID")
+    public void canCreateProductWithId(){
+        Product product = new Product(1);
+        assertThat(product.getId()).isEqualTo(1);
     }
 }

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import org.example.entities.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductTest {
+    @Test
+    @DisplayName("Can create a valid Product instance")
+    public void canCreateProduct() {
+        Product product = new Product();
+
+        assertThat(product).isNotNull();
+    }
+}

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -4,6 +4,9 @@ import org.example.entities.Category;
 import org.example.entities.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,7 +18,6 @@ public class ProductTest {
         Product product = new Product(1);
         assertThat(product.getId()).isEqualTo(1);
     }
-
 
     @Test
     @DisplayName("Can create a Product with a name")
@@ -36,5 +38,17 @@ public class ProductTest {
     public void canCreateProductWithRating() {
         Product product = new Product(1, "Laptop", Category.GENERAL, 1.5);
         assertThat(product.getRating()).isEqualTo(1.5);
+    }
+
+    @Test
+    @DisplayName("Can create a Product with a created date")
+    public void canCreateProductWithGetCreatedDate() {
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDate currentDate = LocalDate.of(2025, 1, 1);
+            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
+
+            Product product = new Product(1, "Laptop", Category.GENERAL, 1.5);
+            assertThat(product.getCreatedDate()).isEqualTo(currentDate);
+        }
     }
 }

--- a/src/test/java/org/example/ProductTest.java
+++ b/src/test/java/org/example/ProductTest.java
@@ -14,4 +14,12 @@ public class ProductTest {
         Product product = new Product(1);
         assertThat(product.getId()).isEqualTo(1);
     }
+
+
+    @Test
+    @DisplayName("Can create a Product with a name")
+    public void canCreateProductWithName(){
+        Product product = new Product(1, "Laptop");
+        assertThat(product.getName()).isEqualTo("Laptop");
+    }
 }

--- a/src/test/java/org/example/entities/ProductTest.java
+++ b/src/test/java/org/example/entities/ProductTest.java
@@ -6,6 +6,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,9 +43,9 @@ public class ProductTest {
     @Test
     @DisplayName("Product constructor: sets createdDate")
     public void canCreateProductWithGetCreatedDate() {
-        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
-            LocalDate currentDate = LocalDate.of(2025, 1, 1);
-            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDateTime currentDate = LocalDateTime.of(2025, 1, 1, 18, 0, 0, 0);
+            mockedStatic.when(LocalDateTime::now).thenReturn(currentDate);
 
             Product product = new Product("1", "Laptop", Category.GENERAL, 1);
             assertThat(product.getCreatedDate()).isEqualTo(currentDate);
@@ -57,15 +58,15 @@ public class ProductTest {
         Product product;
         Product updated;
 
-        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
-            LocalDate currentDate = LocalDate.of(2025, 1, 1);
-            mockedStatic.when(LocalDate::now).thenReturn(currentDate);
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDateTime currentDate = LocalDateTime.of(2025, 1, 1, 18, 0, 0, 0);
+            mockedStatic.when(LocalDateTime::now).thenReturn(currentDate);
             product = new Product("1", "Laptop", Category.GENERAL, 1);
         }
 
-        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
-            LocalDate updateDate = LocalDate.of(2025, 1, 5);
-            mockedStatic.when(LocalDate::now).thenReturn(updateDate);
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDateTime updateDate = LocalDateTime.of(2025, 1, 5, 18, 0, 0, 0);
+            mockedStatic.when(LocalDateTime::now).thenReturn(updateDate);
             updated = product.update("Notebook", Category.GENERAL, 2);
 
             assertThat(updated.getModifiedDate()).isEqualTo(updateDate);

--- a/src/test/java/org/example/entities/ProductTest.java
+++ b/src/test/java/org/example/entities/ProductTest.java
@@ -12,35 +12,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ProductTest {
 
     @Test
-    @DisplayName("Can create a Product with a unique ID")
+    @DisplayName("Product constructor: sets unique ID")
     public void canCreateProductWithId() {
         Product product = new Product(1);
         assertThat(product.getId()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("Can create a Product with a name")
+    @DisplayName("Product constructor: sets name")
     public void canCreateProductWithName() {
         Product product = new Product(1, "Laptop");
         assertThat(product.getName()).isEqualTo("Laptop");
     }
 
     @Test
-    @DisplayName("Can create a Product with a category")
+    @DisplayName("Product constructor: sets category")
     public void canCreateProductWithCategory() {
         Product product = new Product(1, "Laptop", Category.GENERAL);
         assertThat(product.getCategory()).isEqualTo(Category.GENERAL);
     }
 
     @Test
-    @DisplayName("Can create a Product with a rating")
+    @DisplayName("Product constructor: sets rating")
     public void canCreateProductWithRating() {
         Product product = new Product(1, "Laptop", Category.GENERAL, 1);
         assertThat(product.getRating()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("Can create a Product with a created date")
+    @DisplayName("Product constructor: sets createdDate")
     public void canCreateProductWithGetCreatedDate() {
         try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
             LocalDate currentDate = LocalDate.of(2025, 1, 1);
@@ -52,7 +52,7 @@ public class ProductTest {
     }
 
     @Test
-    @DisplayName("Can update a Product's modified date when name is changed")
+    @DisplayName("update(): updates modifiedDate and returns new Product")
     public void canCreateProductWithModifiedDate() {
         Product product;
         Product updated;

--- a/src/test/java/org/example/entities/ProductTest.java
+++ b/src/test/java/org/example/entities/ProductTest.java
@@ -1,7 +1,5 @@
-package org.example;
+package org.example.entities;
 
-import org.example.entities.Category;
-import org.example.entities.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;

--- a/src/test/java/org/example/entities/ProductTest.java
+++ b/src/test/java/org/example/entities/ProductTest.java
@@ -14,28 +14,28 @@ public class ProductTest {
     @Test
     @DisplayName("Product constructor: sets unique ID")
     public void canCreateProductWithId() {
-        Product product = new Product(1);
-        assertThat(product.getId()).isEqualTo(1);
+        Product product = new Product("1");
+        assertThat(product.getId()).isEqualTo("1");
     }
 
     @Test
     @DisplayName("Product constructor: sets name")
     public void canCreateProductWithName() {
-        Product product = new Product(1, "Laptop");
+        Product product = new Product("1", "Laptop");
         assertThat(product.getName()).isEqualTo("Laptop");
     }
 
     @Test
     @DisplayName("Product constructor: sets category")
     public void canCreateProductWithCategory() {
-        Product product = new Product(1, "Laptop", Category.GENERAL);
+        Product product = new Product("1", "Laptop", Category.GENERAL);
         assertThat(product.getCategory()).isEqualTo(Category.GENERAL);
     }
 
     @Test
     @DisplayName("Product constructor: sets rating")
     public void canCreateProductWithRating() {
-        Product product = new Product(1, "Laptop", Category.GENERAL, 1);
+        Product product = new Product("1", "Laptop", Category.GENERAL, 1);
         assertThat(product.getRating()).isEqualTo(1);
     }
 
@@ -46,7 +46,7 @@ public class ProductTest {
             LocalDate currentDate = LocalDate.of(2025, 1, 1);
             mockedStatic.when(LocalDate::now).thenReturn(currentDate);
 
-            Product product = new Product(1, "Laptop", Category.GENERAL, 1);
+            Product product = new Product("1", "Laptop", Category.GENERAL, 1);
             assertThat(product.getCreatedDate()).isEqualTo(currentDate);
         }
     }
@@ -60,7 +60,7 @@ public class ProductTest {
         try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
             LocalDate currentDate = LocalDate.of(2025, 1, 1);
             mockedStatic.when(LocalDate::now).thenReturn(currentDate);
-            product = new Product(1, "Laptop", Category.GENERAL, 1);
+            product = new Product("1", "Laptop", Category.GENERAL, 1);
         }
 
         try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -21,10 +22,10 @@ public class WarehouseTest {
         return product;
     }
 
-    private Product createProductWithMockedDate(String id, String name, Category category, int rating, int year, int month, int day) {
-        LocalDate mockedDate = LocalDate.of(year, month, day);
-        try (MockedStatic<LocalDate> mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
-            mockedStatic.when(LocalDate::now).thenReturn(mockedDate);
+    private Product createProductWithMockedDate(String id, String name, Category category, int rating, int year, int month, int day, int hour, int minute, int second) {
+        LocalDateTime mockedDate = LocalDateTime.of(year, month, day, hour, minute, second, 0);
+        try (MockedStatic<LocalDateTime> mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatic.when(LocalDateTime::now).thenReturn(mockedDate);
             return new Product(id, name, category, rating);
         }
     }
@@ -72,7 +73,7 @@ public class WarehouseTest {
     @DisplayName("updateProduct: updates an existing Product without changing createdDate")
     public void updateProductWithoutChangingCreatedDate() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = createProductWithMockedDate("1", "Test Product", Category.GENERAL, 1, 2024, 1, 5);
+        Product testProduct = createProductWithMockedDate("1", "Test Product", Category.GENERAL, 1, 2024, 1, 5, 18, 0, 0);
         warehouse.addProduct(testProduct);
 
         assertThat(warehouse.getProductById("1").get().getCreatedDate()).isEqualTo(testProduct.getCreatedDate());
@@ -181,14 +182,14 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("getProductsCreatedAfter(LocalDate date): returns Products created after a given date")
+    @DisplayName("getProductsCreatedAfter(LocalDateTime date): returns Products created after a given date")
     public void getProductsCreatedAfter() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5);
-        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27);
-        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31);
-        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24);
-        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1);
+        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5, 18, 0, 0);
+        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27, 18, 0, 0);
+        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31, 18, 0, 0);
+        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24, 18, 0, 0);
+        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1, 18, 0, 0);
 
         warehouse.addProduct(testProduct1);
         warehouse.addProduct(testProduct2);
@@ -196,7 +197,7 @@ public class WarehouseTest {
         warehouse.addProduct(testProduct4);
         warehouse.addProduct(testProduct5);
 
-        LocalDate testDate = LocalDate.of(1997, 2, 1);
+        LocalDateTime testDate = LocalDateTime.of(1997, 2, 1, 18, 0, 0, 0);
         assertThat(warehouse.getProductsCreatedAfter(testDate)).extracting(Product::getName).containsExactly("Laptop", "Desk Chair", "Pen Set");
     }
 
@@ -204,11 +205,11 @@ public class WarehouseTest {
     @DisplayName("getProductsCreatedAfter(LocalDate date): throws an exception if invalid input")
     public void getProductsCreatedAfterEmptyList() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5);
-        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27);
-        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31);
-        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24);
-        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1);
+        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5, 18, 0, 0);
+        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27, 18, 0, 0);
+        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31, 18, 0, 0);
+        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24, 18, 0, 0);
+        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1, 18, 0, 0);
 
         warehouse.addProduct(testProduct1);
         warehouse.addProduct(testProduct2);

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -10,8 +10,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WarehouseTest {
 
+    // Helper methods
+    private Product addProductToWarehouse(Warehouse warehouse, String id, String name, Category category) {
+        Product product = new Product(id, name, category, 1);
+        warehouse.addProduct(product);
+        return product;
+    }
+
     @Test
-    @DisplayName("addProduct: adds a new product to Warehouse")
+    @DisplayName("addProduct: adds a new Product to Warehouse")
     public void addProduct() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
@@ -21,7 +28,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("addProduct: throws IllegalArgumentException if product name is blank")
+    @DisplayName("addProduct: throws IllegalArgumentException if Product name is blank")
     public void throwExceptionIfNoProductNameProvided() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("1", "", Category.GENERAL, 1);
@@ -31,7 +38,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("updateProduct: updates an existing product by ID")
+    @DisplayName("updateProduct: updates an existing Product by ID")
     public void updateProduct() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
@@ -46,7 +53,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("updateProduct: throws IllegalArgumentException if product ID is not found")
+    @DisplayName("updateProduct: throws IllegalArgumentException if Product ID is not found")
     public void throwExceptionIfNoProductFoundToUpdate() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
@@ -58,7 +65,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("getAllProducts: returns all products in warehouse")
+    @DisplayName("getAllProducts: returns all Products in Warehouse")
     public void getAllProducts() {
         Warehouse warehouse = new Warehouse();
 
@@ -73,7 +80,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("getAllProducts: returns empty list if warehouse is empty")
+    @DisplayName("getAllProducts: returns empty list if Warehouse is empty")
     public void getAllProductsEmptyWarehouse() {
         Warehouse warehouse = new Warehouse();
         assertThat(warehouse.getAllProducts()).isEmpty();
@@ -90,7 +97,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("getProductById: throws IllegalArgumentException if product ID is not found")
+    @DisplayName("getProductById: throws IllegalArgumentException if Product ID is not found")
     public void throwExceptionIfNoProductFound() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
@@ -98,6 +105,34 @@ public class WarehouseTest {
 
         assertThatThrownBy(() -> warehouse.getProductById("100"))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("getProductsByCategorySorted: returns Products in a category, sorted A-Z by name")
+    public void getProductsByCategorySorted() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
+        Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.GENERAL);
+        Product testProduct5 = addProductToWarehouse(warehouse, "5", "Candy", Category.GENERAL);
+        Product testProduct6 = addProductToWarehouse(warehouse, "6", "VR Glasses", Category.GENERAL);
+        Product testProduct7 = addProductToWarehouse(warehouse, "7", "Android TV", Category.ELECTRONICS);
+
+        assertThat(warehouse.getProductsByCategorySorted(Category.GENERAL))
+                .extracting(Product::getName)
+                .containsExactly("Candy", "Computer", "Laptop", "Sandwich", "Television", "VR Glasses");
+    }
+
+    @Test
+    @DisplayName("getProductsByCategorySorted: returns empty list if Category is empty")
+    public void getProductsByCategorySortedEmptyCategory() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
+
+        assertThat(warehouse.getProductsByCategorySorted(Category.ELECTRONICS)).isEmpty();
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -29,4 +29,19 @@ public class WarehouseTest {
         assertThatThrownBy(() -> warehouse.addProduct(testProduct))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    @DisplayName("Update an existing product in Warehouse by searching with id")
+    public void updateProduct() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+        Product updatedTestProduct = new Product(1, "Update Test Product", Category.GENERAL, 1);
+        warehouse.updateProduct(updatedTestProduct);
+
+        assertThat(warehouse.getAllProducts()).contains(updatedTestProduct);
+        assertThat(warehouse.getAllProducts()).doesNotContain(testProduct);
+        assertThat(warehouse.getAllProducts().size()).isEqualTo(1);
+    }
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -221,6 +221,34 @@ public class WarehouseTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    @DisplayName("getModifiedProducts(): returns Products where createdDate != modifiedDate")
+    public void getModifiedProductsNotEqualToCreatedDate() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
 
+        //Delay a bit to make sure modifiedDate is different from createdDate
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        warehouse.updateProduct("1", "Desktop", Category.GENERAL, 10);
+
+        assertThat(warehouse.getModifiedProducts()).extracting(Product::getName).containsExactly("Desktop");
+    }
+
+    @Test
+    @DisplayName("getModifiedProducts(): returns an empty list if no products found")
+    public void getModifiedProductsEmptyList() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
+
+        assertThat(warehouse.getModifiedProducts()).isEmpty();
+    }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -57,7 +57,7 @@ public class WarehouseTest {
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        // Use the new method signature
+
         warehouse.updateProduct("1", "Updated Test Product", Category.ELECTRONICS, 5);
 
         Product updatedProduct = warehouse.getProductById("1").get();
@@ -66,6 +66,16 @@ public class WarehouseTest {
         assertThat(updatedProduct.getRating()).isEqualTo(5);
         assertThat(updatedProduct.getId()).isEqualTo("1");
         assertThat(warehouse.getAllProducts().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("updateProduct: updates an existing Product without changing createdDate")
+    public void updateProductWithoutChangingCreatedDate() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = createProductWithMockedDate("1", "Test Product", Category.GENERAL, 1, 2024, 1, 5);
+        warehouse.addProduct(testProduct);
+
+        assertThat(warehouse.getProductById("1").get().getCreatedDate()).isEqualTo(testProduct.getCreatedDate());
     }
 
     @Test

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -57,11 +57,14 @@ public class WarehouseTest {
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        Product updatedTestProduct = new Product("1", "Update Test Product", Category.GENERAL, 1);
-        warehouse.updateProduct(updatedTestProduct);
+        // Use the new method signature
+        warehouse.updateProduct("1", "Updated Test Product", Category.ELECTRONICS, 5);
 
-        assertThat(warehouse.getAllProducts()).contains(updatedTestProduct);
-        assertThat(warehouse.getAllProducts()).doesNotContain(testProduct);
+        Product updatedProduct = warehouse.getProductById("1").get();
+        assertThat(updatedProduct.getName()).isEqualTo("Updated Test Product");
+        assertThat(updatedProduct.getCategory()).isEqualTo(Category.ELECTRONICS);
+        assertThat(updatedProduct.getRating()).isEqualTo(5);
+        assertThat(updatedProduct.getId()).isEqualTo("1");
         assertThat(warehouse.getAllProducts().size()).isEqualTo(1);
     }
 
@@ -72,8 +75,7 @@ public class WarehouseTest {
         Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        Product updatedTestProduct = new Product("2", "Update Test Product", Category.GENERAL, 1);
-        assertThatThrownBy(() -> warehouse.updateProduct(updatedTestProduct))
+        assertThatThrownBy(() -> warehouse.updateProduct("2", "Updated Product", Category.GENERAL, 2))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mockito;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -26,7 +27,7 @@ public class WarehouseTest {
 
     // Helper methods
     private Product addProductToWarehouse(Warehouse warehouse, String id, String name, Category category, int rating) {
-        Product product = new Product(id, name, category, 1);
+        Product product = new Product(id, name, category, rating);
         warehouse.addProduct(product);
         return product;
     }
@@ -368,6 +369,36 @@ public class WarehouseTest {
     public void getProductInitialsMapEmptyList() {
         Warehouse warehouse = new Warehouse();
         assertThat(warehouse.getProductInitialsMap().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("getTopRatedProductsThisMonth(): returns Products with max rating, created this month, sorted by newest first")
+    public void getTopRatedProductsThisMonth() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 9, 2002, 1, 1, 18, 0, 0);
+        Product testProduct2 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 10, 1782, 8, 24, 18, 0, 0);
+        warehouse.addProduct(testProduct1);
+        warehouse.addProduct(testProduct2);
+
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDateTime date1 = LocalDateTime.of(2025, 1, 18, 18, 0, 0, 0);
+            LocalDateTime date2 = LocalDateTime.of(2025, 1, 18, 18, 0, 1, 0);
+            LocalDateTime date3 = LocalDateTime.of(2025, 1, 18, 18, 0, 2, 0);
+
+            mockedStatic.when(LocalDateTime::now)
+                    .thenReturn(date1)
+                    .thenReturn(date2)
+                    .thenReturn(date3);
+
+            Product testProduct3 = addProductToWarehouse(warehouse, "1", "Laptop", ELECTRONICS, 10);
+            Product testProduct4 = addProductToWarehouse(warehouse, "2", "Television", ELECTRONICS, 10);
+            Product testProduct5 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 9);
+
+            List<Product> expectedProducts = warehouse.getTopRatedProductsThisMonth();
+
+            assertThat(expectedProducts.size()).isEqualTo(2);
+            assertThat(expectedProducts).containsExactly(testProduct4, testProduct3);
+        }
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class WarehouseTest {
 
     // Helper methods
-    private Product addProductToWarehouse(Warehouse warehouse, String id, String name, Category category) {
+    private Product addProductToWarehouse(Warehouse warehouse, String id, String name, Category category, int rating) {
         Product product = new Product(id, name, category, 1);
         warehouse.addProduct(product);
         return product;
@@ -185,13 +185,13 @@ public class WarehouseTest {
     @DisplayName("getProductsByCategorySorted: returns Products in a category, sorted A-Z by name")
     public void getProductsByCategorySorted() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
-        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
-        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
-        Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.GENERAL);
-        Product testProduct5 = addProductToWarehouse(warehouse, "5", "Candy", Category.GENERAL);
-        Product testProduct6 = addProductToWarehouse(warehouse, "6", "VR Glasses", Category.GENERAL);
-        Product testProduct7 = addProductToWarehouse(warehouse, "7", "Android TV", Category.ELECTRONICS);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL, 1);
+        Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.GENERAL, 1);
+        Product testProduct5 = addProductToWarehouse(warehouse, "5", "Candy", Category.GENERAL, 1);
+        Product testProduct6 = addProductToWarehouse(warehouse, "6", "VR Glasses", Category.GENERAL, 1);
+        Product testProduct7 = addProductToWarehouse(warehouse, "7", "Android TV", Category.ELECTRONICS, 1);
 
         assertThat(warehouse.getProductsByCategorySorted(Category.GENERAL))
                 .extracting(Product::getName)
@@ -202,9 +202,9 @@ public class WarehouseTest {
     @DisplayName("getProductsByCategorySorted: returns empty list if Category is empty")
     public void getProductsByCategorySortedEmptyCategory() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
-        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
-        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL, 1);
 
         assertThat(warehouse.getProductsByCategorySorted(Category.ELECTRONICS)).isEmpty();
     }
@@ -213,7 +213,7 @@ public class WarehouseTest {
     @DisplayName("getProductsByCategorySorted: throws exception if invalid input")
     public void throwsExceptionIfNoCategoryProvided() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL, 1);
 
         assertThatThrownBy(() -> warehouse.getProductsByCategorySorted(null))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -263,9 +263,9 @@ public class WarehouseTest {
     @DisplayName("getModifiedProducts(): returns Products where createdDate != modifiedDate")
     public void getModifiedProductsNotEqualToCreatedDate() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
-        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
-        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL, 1);
 
         //Delay a bit to make sure modifiedDate is different from createdDate
         try {
@@ -283,8 +283,8 @@ public class WarehouseTest {
     @DisplayName("getModifiedProducts(): returns an empty list if no products found")
     public void getModifiedProductsEmptyList() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
-        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
 
         assertThat(warehouse.getModifiedProducts()).isEmpty();
     }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class WarehouseTest {
 
     @Test
-    @DisplayName("Add a new product to Warehouse")
+    @DisplayName("addProduct: adds a new product to Warehouse")
     public void addProduct() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
@@ -21,7 +21,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("Throw exception if no Product name is provided")
+    @DisplayName("addProduct: throws IllegalArgumentException if product name is blank")
     public void throwExceptionIfNoProductNameProvided() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product(1, "", Category.GENERAL, 1);
@@ -31,7 +31,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("Update an existing product in Warehouse by searching with id")
+    @DisplayName("updateProduct: updates an existing product by ID")
     public void updateProduct() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
@@ -46,7 +46,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("Throw exception if no Product is found to update")
+    @DisplayName("updateProduct: throws IllegalArgumentException if product ID is not found")
     public void throwExceptionIfNoProductFoundToUpdate() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
@@ -58,7 +58,7 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("Get all products from Warehouse")
+    @DisplayName("getAllProducts: returns all products in warehouse")
     public void getAllProducts() {
         Warehouse warehouse = new Warehouse();
 

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -401,4 +401,24 @@ public class WarehouseTest {
         }
     }
 
+    @Test
+    @DisplayName("getTopRatedProductsThisMonth(): returns an empty list if no products found")
+    public void getTopRatedProductsThisMonthEmptyList() {
+        Warehouse warehouse = new Warehouse();
+        assertThat(warehouse.getTopRatedProductsThisMonth()).isEmpty();
+        Product testProduct1 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 9, 2025, 1, 31, 23, 59, 59);
+        warehouse.addProduct(testProduct1);
+
+        try (MockedStatic mockedStatic = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDateTime date1 = LocalDateTime.of(2025, 2, 1, 00, 00, 00, 0);
+
+            mockedStatic.when(LocalDateTime::now)
+                    .thenReturn(date1);
+
+            List<Product> expectedProducts = warehouse.getTopRatedProductsThisMonth();
+
+            assertThat(expectedProducts).isEmpty();
+        }
+    }
+
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -106,17 +106,27 @@ public class WarehouseTest {
         Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        assertThat(warehouse.getProductById("99")).isEqualTo(testProduct);
+        assertThat(warehouse.getProductById("99")).contains(testProduct);
     }
 
     @Test
-    @DisplayName("getProductById: throws IllegalArgumentException if Product ID is not found")
-    public void throwExceptionIfNoProductFound() {
+    @DisplayName("getProductById: returns empty Optional if Product ID is not found")
+    public void returnsEmptyOptionalIfNoProductFound() {
         Warehouse warehouse = new Warehouse();
         Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        assertThatThrownBy(() -> warehouse.getProductById("100"))
+        assertThat(warehouse.getProductById("100")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getProductById: throws exception if invalid input")
+    public void throwsExceptionIfNoProductIdProvided() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+        assertThatThrownBy(() -> warehouse.getProductById(""))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -73,10 +73,31 @@ public class WarehouseTest {
     }
 
     @Test
-    @DisplayName("getAllProducts returns empty list if warehouse is empty")
+    @DisplayName("getAllProducts: returns empty list if warehouse is empty")
     public void getAllProductsEmptyWarehouse() {
         Warehouse warehouse = new Warehouse();
         assertThat(warehouse.getAllProducts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getProductById: returns a Product by id")
+    public void getProductById() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(99, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+        assertThat(warehouse.getProductById(99)).isEqualTo(testProduct);
+    }
+
+    @Test
+    @DisplayName("getProductById: throws IllegalArgumentException if product ID is not found")
+    public void throwExceptionIfNoProductFound() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(99, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+        assertThatThrownBy(() -> warehouse.getProductById(100))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -277,6 +277,7 @@ public class WarehouseTest {
         warehouse.updateProduct("1", "Desktop", Category.GENERAL, 10);
 
         assertThat(warehouse.getModifiedProducts()).extracting(Product::getName).containsExactly("Desktop");
+        assertThat(warehouse.getModifiedProducts().size()).isEqualTo(1);
     }
 
     @Test
@@ -287,6 +288,26 @@ public class WarehouseTest {
         Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
 
         assertThat(warehouse.getModifiedProducts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getCategoriesWithProducts(): return all categories with at least one product")
+    public void getCategoriesWithProducts() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.ELECTRONICS, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "3", "Television", Category.ELECTRONICS, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "1", "Apple", Category.FOOD, 1);
+
+        assertThat(warehouse.getCategoriesWithProducts().size()).isEqualTo(2);
+        assertThat(warehouse.getCategoriesWithProducts()).containsExactlyInAnyOrder(Category.ELECTRONICS, Category.FOOD);
+    }
+
+    @Test
+    @DisplayName("getCategoriesWithProducts(): return empty list if no products found")
+    public void getCategoriesWithProductsEmptyList() {
+        Warehouse warehouse = new Warehouse();
+
+        assertThat(warehouse.getCategoriesWithProducts()).isEmpty();
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mockito;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -340,6 +342,32 @@ public class WarehouseTest {
 
         assertThatThrownBy(() -> warehouse.countProductsInCategory(null))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("getProductInitialsMap(): returns a Map<Character, Integer> of first letters in product names and their counts")
+    public void getProductInitialsMap() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", ELECTRONICS, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Camera", ELECTRONICS, 1);
+        Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.FOOD, 1);
+        Product testProduct5 = addProductToWarehouse(warehouse, "5", "Sushi", Category.FOOD, 1);
+
+        Map<Character, Integer> expectedMap = warehouse.getProductInitialsMap();
+        System.out.println(expectedMap);
+
+        assertThat(expectedMap.size()).isEqualTo(3);
+        assertThat(expectedMap.get('L')).isEqualTo(1);
+        assertThat(expectedMap.get('C')).isEqualTo(2);
+        assertThat(expectedMap.get('S')).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("getProductInitialsMap(): returns an empty Map if no products found")
+    public void getProductInitialsMapEmptyList() {
+        Warehouse warehouse = new Warehouse();
+        assertThat(warehouse.getProductInitialsMap().size()).isEqualTo(0);
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -4,6 +4,10 @@ import org.example.entities.Category;
 import org.example.entities.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +21,15 @@ public class WarehouseTest {
         return product;
     }
 
+    private Product createProductWithMockedDate(String id, String name, Category category, int rating, int year, int month, int day) {
+        LocalDate mockedDate = LocalDate.of(year, month, day);
+        try (MockedStatic<LocalDate> mockedStatic = Mockito.mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatic.when(LocalDate::now).thenReturn(mockedDate);
+            return new Product(id, name, category, rating);
+        }
+    }
+
+    // Tests
     @Test
     @DisplayName("addProduct: adds a new Product to Warehouse")
     public void addProduct() {
@@ -134,5 +147,47 @@ public class WarehouseTest {
 
         assertThat(warehouse.getProductsByCategorySorted(Category.ELECTRONICS)).isEmpty();
     }
+
+    @Test
+    @DisplayName("getProductsCreatedAfter(LocalDate date): returns Products created after a given date")
+    public void getProductsCreatedAfter() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5);
+        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27);
+        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31);
+        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24);
+        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1);
+
+        warehouse.addProduct(testProduct1);
+        warehouse.addProduct(testProduct2);
+        warehouse.addProduct(testProduct3);
+        warehouse.addProduct(testProduct4);
+        warehouse.addProduct(testProduct5);
+
+        LocalDate testDate = LocalDate.of(1997, 2, 1);
+        assertThat(warehouse.getProductsCreatedAfter(testDate)).extracting(Product::getName).containsExactly("Laptop", "Desk Chair", "Pen Set");
+    }
+
+    @Test
+    @DisplayName("getProductsCreatedAfter(LocalDate date): throws an exception if invalid input")
+    public void getProductsCreatedAfterEmptyList() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = createProductWithMockedDate("1", "Laptop", Category.GENERAL, 1, 2025, 1, 5);
+        Product testProduct2 = createProductWithMockedDate("2", "Notebook", Category.GENERAL, 1, 1997, 1, 27);
+        Product testProduct3 = createProductWithMockedDate("2", "Desk Chair", Category.GENERAL, 1, 1997, 3, 31);
+        Product testProduct4 = createProductWithMockedDate("3", "Water Bottle", Category.GENERAL, 1, 1782, 8, 24);
+        Product testProduct5 = createProductWithMockedDate("4", "Pen Set", Category.GENERAL, 1, 2002, 1, 1);
+
+        warehouse.addProduct(testProduct1);
+        warehouse.addProduct(testProduct2);
+        warehouse.addProduct(testProduct3);
+        warehouse.addProduct(testProduct4);
+        warehouse.addProduct(testProduct5);
+
+        assertThatThrownBy(() -> warehouse.getProductsCreatedAfter(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -4,11 +4,17 @@ import org.example.entities.Category;
 import org.example.entities.Product;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -88,6 +94,38 @@ public class WarehouseTest {
 
         assertThatThrownBy(() -> warehouse.updateProduct("2", "Updated Product", Category.GENERAL, 2))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testBlankIncludeNull")
+    @DisplayName("updateProduct: throws IllegalArgumentException for invalid inputs")
+    void throwExceptionIfInvalidInputToUpdate(String id, String name, Category category, int rating) {
+        Warehouse warehouse = new Warehouse();
+        warehouse.addProduct(new Product("1", "Laptop", Category.GENERAL, 1));
+
+        assertThatThrownBy(() -> warehouse.updateProduct(id, name, category, rating))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    static Stream<Arguments> testBlankIncludeNull() {
+        return Stream.of(
+                //Id
+                Arguments.of(null, "Test Product", Category.GENERAL, 5),
+                Arguments.of("", "Test Product", Category.GENERAL, 5),
+                Arguments.of(" ", "Test Product", Category.GENERAL, 5),
+
+                //Name
+                Arguments.of("1", null, Category.GENERAL, 5),
+                Arguments.of("1", "", Category.GENERAL, 5),
+                Arguments.of("1", " ", Category.GENERAL, 5),
+
+                //Category
+                Arguments.of("1", "Test Product", null, 5),
+
+                //Rating
+                Arguments.of("1", "Test Product", Category.GENERAL, 11),
+                Arguments.of("1", "Test Product", Category.GENERAL, 0)
+        );
     }
 
     @Test
@@ -231,7 +269,7 @@ public class WarehouseTest {
 
         //Delay a bit to make sure modifiedDate is different from createdDate
         try {
-            Thread.sleep(5000);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -44,4 +44,17 @@ public class WarehouseTest {
         assertThat(warehouse.getAllProducts()).doesNotContain(testProduct);
         assertThat(warehouse.getAllProducts().size()).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("Throw exception if no Product is found to update")
+    public void throwExceptionIfNoProductFoundToUpdate() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+        Product updatedTestProduct = new Product(2, "Update Test Product", Category.GENERAL, 1);
+        assertThatThrownBy(() -> warehouse.updateProduct(updatedTestProduct))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -14,7 +14,7 @@ public class WarehouseTest {
     @DisplayName("addProduct: adds a new product to Warehouse")
     public void addProduct() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
         assertThat(warehouse.getAllProducts()).contains(testProduct);
@@ -24,7 +24,7 @@ public class WarehouseTest {
     @DisplayName("addProduct: throws IllegalArgumentException if product name is blank")
     public void throwExceptionIfNoProductNameProvided() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(1, "", Category.GENERAL, 1);
+        Product testProduct = new Product("1", "", Category.GENERAL, 1);
 
         assertThatThrownBy(() -> warehouse.addProduct(testProduct))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -34,10 +34,10 @@ public class WarehouseTest {
     @DisplayName("updateProduct: updates an existing product by ID")
     public void updateProduct() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        Product updatedTestProduct = new Product(1, "Update Test Product", Category.GENERAL, 1);
+        Product updatedTestProduct = new Product("1", "Update Test Product", Category.GENERAL, 1);
         warehouse.updateProduct(updatedTestProduct);
 
         assertThat(warehouse.getAllProducts()).contains(updatedTestProduct);
@@ -49,10 +49,10 @@ public class WarehouseTest {
     @DisplayName("updateProduct: throws IllegalArgumentException if product ID is not found")
     public void throwExceptionIfNoProductFoundToUpdate() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        Product testProduct = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        Product updatedTestProduct = new Product(2, "Update Test Product", Category.GENERAL, 1);
+        Product updatedTestProduct = new Product("2", "Update Test Product", Category.GENERAL, 1);
         assertThatThrownBy(() -> warehouse.updateProduct(updatedTestProduct))
                 .isInstanceOf(IllegalArgumentException.class);
     }
@@ -62,10 +62,10 @@ public class WarehouseTest {
     public void getAllProducts() {
         Warehouse warehouse = new Warehouse();
 
-        Product testProduct1 = new Product(1, "Test Product", Category.GENERAL, 1);
+        Product testProduct1 = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct1);
 
-        Product testProduct2 = new Product(1, "Test Product", Category.GENERAL, 1);
+        Product testProduct2 = new Product("1", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct2);
 
         assertThat(warehouse.getAllProducts()).contains(testProduct1, testProduct2);
@@ -83,20 +83,20 @@ public class WarehouseTest {
     @DisplayName("getProductById: returns a Product by id")
     public void getProductById() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(99, "Test Product", Category.GENERAL, 1);
+        Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        assertThat(warehouse.getProductById(99)).isEqualTo(testProduct);
+        assertThat(warehouse.getProductById("99")).isEqualTo(testProduct);
     }
 
     @Test
     @DisplayName("getProductById: throws IllegalArgumentException if product ID is not found")
     public void throwExceptionIfNoProductFound() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct = new Product(99, "Test Product", Category.GENERAL, 1);
+        Product testProduct = new Product("99", "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-        assertThatThrownBy(() -> warehouse.getProductById(100))
+        assertThatThrownBy(() -> warehouse.getProductById("100"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.entities.Category.ELECTRONICS;
 
 public class WarehouseTest {
 
@@ -65,11 +66,11 @@ public class WarehouseTest {
         warehouse.addProduct(testProduct);
 
 
-        warehouse.updateProduct("1", "Updated Test Product", Category.ELECTRONICS, 5);
+        warehouse.updateProduct("1", "Updated Test Product", ELECTRONICS, 5);
 
         Product updatedProduct = warehouse.getProductById("1").get();
         assertThat(updatedProduct.getName()).isEqualTo("Updated Test Product");
-        assertThat(updatedProduct.getCategory()).isEqualTo(Category.ELECTRONICS);
+        assertThat(updatedProduct.getCategory()).isEqualTo(ELECTRONICS);
         assertThat(updatedProduct.getRating()).isEqualTo(5);
         assertThat(updatedProduct.getId()).isEqualTo("1");
         assertThat(warehouse.getAllProducts().size()).isEqualTo(1);
@@ -191,7 +192,7 @@ public class WarehouseTest {
         Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.GENERAL, 1);
         Product testProduct5 = addProductToWarehouse(warehouse, "5", "Candy", Category.GENERAL, 1);
         Product testProduct6 = addProductToWarehouse(warehouse, "6", "VR Glasses", Category.GENERAL, 1);
-        Product testProduct7 = addProductToWarehouse(warehouse, "7", "Android TV", Category.ELECTRONICS, 1);
+        Product testProduct7 = addProductToWarehouse(warehouse, "7", "Android TV", ELECTRONICS, 1);
 
         assertThat(warehouse.getProductsByCategorySorted(Category.GENERAL))
                 .extracting(Product::getName)
@@ -206,7 +207,7 @@ public class WarehouseTest {
         Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
         Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", Category.GENERAL, 1);
 
-        assertThat(warehouse.getProductsByCategorySorted(Category.ELECTRONICS)).isEmpty();
+        assertThat(warehouse.getProductsByCategorySorted(ELECTRONICS)).isEmpty();
     }
 
     @Test
@@ -294,12 +295,12 @@ public class WarehouseTest {
     @DisplayName("getCategoriesWithProducts(): return all categories with at least one product")
     public void getCategoriesWithProducts() {
         Warehouse warehouse = new Warehouse();
-        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.ELECTRONICS, 1);
-        Product testProduct2 = addProductToWarehouse(warehouse, "3", "Television", Category.ELECTRONICS, 1);
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", ELECTRONICS, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "3", "Television", ELECTRONICS, 1);
         Product testProduct3 = addProductToWarehouse(warehouse, "1", "Apple", Category.FOOD, 1);
 
         assertThat(warehouse.getCategoriesWithProducts().size()).isEqualTo(2);
-        assertThat(warehouse.getCategoriesWithProducts()).containsExactlyInAnyOrder(Category.ELECTRONICS, Category.FOOD);
+        assertThat(warehouse.getCategoriesWithProducts()).containsExactlyInAnyOrder(ELECTRONICS, Category.FOOD);
     }
 
     @Test
@@ -308,6 +309,37 @@ public class WarehouseTest {
         Warehouse warehouse = new Warehouse();
 
         assertThat(warehouse.getCategoriesWithProducts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("countProductsInCategory(): returns number of products in a category")
+    public void countProductsInCategoryCountsProducts() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", ELECTRONICS, 1);
+        Product testProduct2 = addProductToWarehouse(warehouse, "2", "Computer", Category.GENERAL, 1);
+        Product testProduct3 = addProductToWarehouse(warehouse, "3", "Television", ELECTRONICS, 1);
+        Product testProduct4 = addProductToWarehouse(warehouse, "4", "Sandwich", Category.FOOD, 1);
+
+        assertThat(warehouse.countProductsInCategory(Category.ELECTRONICS)).isEqualTo(2);
+        assertThat(warehouse.countProductsInCategory(Category.GENERAL)).isEqualTo(1);
+        assertThat(warehouse.countProductsInCategory(Category.FOOD)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("countProductsInCategory(): returns 0 if no products found")
+    public void countProductsInCategoryEmptyList() {
+        Warehouse warehouse = new Warehouse();
+        assertThat(warehouse.countProductsInCategory(Category.ELECTRONICS)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("countProductsInCategory(): throws exception if invalid input")
+    public void countProductsInCategoryThrowsException() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", ELECTRONICS, 1);
+
+        assertThatThrownBy(() -> warehouse.countProductsInCategory(null))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -57,4 +57,26 @@ public class WarehouseTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    @DisplayName("Get all products from Warehouse")
+    public void getAllProducts() {
+        Warehouse warehouse = new Warehouse();
+
+        Product testProduct1 = new Product(1, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct1);
+
+        Product testProduct2 = new Product(1, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct2);
+
+        assertThat(warehouse.getAllProducts()).contains(testProduct1, testProduct2);
+        assertThat(warehouse.getAllProducts().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("getAllProducts returns empty list if warehouse is empty")
+    public void getAllProductsEmptyWarehouse() {
+        Warehouse warehouse = new Warehouse();
+        assertThat(warehouse.getAllProducts()).isEmpty();
+    }
+
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -1,0 +1,22 @@
+package org.example.service;
+
+import org.example.entities.Category;
+import org.example.entities.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WarehouseTest {
+
+    @Test
+    @DisplayName("Add a new product to Warehouse")
+    public void addProduct() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
+        warehouse.addProduct(testProduct);
+
+       assertThat(warehouse.getAllProducts()).contains(testProduct);
+    }
+
+}

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WarehouseTest {
 
@@ -16,7 +17,16 @@ public class WarehouseTest {
         Product testProduct = new Product(1, "Test Product", Category.GENERAL, 1);
         warehouse.addProduct(testProduct);
 
-       assertThat(warehouse.getAllProducts()).contains(testProduct);
+        assertThat(warehouse.getAllProducts()).contains(testProduct);
     }
 
+    @Test
+    @DisplayName("Throw exception if no Product name is provided")
+    public void throwExceptionIfNoProductNameProvided() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct = new Product(1, "", Category.GENERAL, 1);
+
+        assertThatThrownBy(() -> warehouse.addProduct(testProduct))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -356,7 +356,6 @@ public class WarehouseTest {
         Product testProduct5 = addProductToWarehouse(warehouse, "5", "Sushi", Category.FOOD, 1);
 
         Map<Character, Integer> expectedMap = warehouse.getProductInitialsMap();
-        System.out.println(expectedMap);
 
         assertThat(expectedMap.size()).isEqualTo(3);
         assertThat(expectedMap.get('L')).isEqualTo(1);

--- a/src/test/java/org/example/service/WarehouseTest.java
+++ b/src/test/java/org/example/service/WarehouseTest.java
@@ -159,6 +159,16 @@ public class WarehouseTest {
     }
 
     @Test
+    @DisplayName("getProductsByCategorySorted: throws exception if invalid input")
+    public void throwsExceptionIfNoCategoryProvided() {
+        Warehouse warehouse = new Warehouse();
+        Product testProduct1 = addProductToWarehouse(warehouse, "1", "Laptop", Category.GENERAL);
+
+        assertThatThrownBy(() -> warehouse.getProductsByCategorySorted(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     @DisplayName("getProductsCreatedAfter(LocalDate date): returns Products created after a given date")
     public void getProductsCreatedAfter() {
         Warehouse warehouse = new Warehouse();


### PR DESCRIPTION
 ## Description
 
 A small Java application for managing products using **Java 8** streams and **JUnit 5** for unit testing. The public interface is a class called `Warehouse` in the service package. All public methods are covered by unit tests.
 
 ### Resolves Issue #7 
 
 ## The Application Supports
 ### Entities

- `Product` class with immutable fields: `id`, `name`, `category`, `rating`, `createdDate`, `modifiedDate`.
- `Category` enum for product categories.
- `Product.update()` returns a new instance, preserving immutability.

 ### Warehouse Functionality
- `addProduct(Product product)`: Add a new product (validate name is not empty).
- `updateProduct(String id, String name, Category category, int rating)`: Modify an existing product.
- `getAllProducts()`: Retrieve all products
- `getProductById(String id)`: Retrieve product by ID
- `getProductsByCategorySorted(Category category)`: Products in a category, sorted A–Z by name
- `getProductsCreatedAfter(LocalDate date)`: Products created after a given date
- `getModifiedProducts()`: Products where `createdDate != modifiedDate`
- `getCategoriesWithProducts()`: Return all categories with at least one product
- `countProductsInCategory(Category category)`: Return number of products in a category
- `getProductInitialsMap()`: Return a `Map<Character, Integer>` of first letters in product names and their counts
- `getTopRatedProductsThisMonth()`: Products with max rating, created this month, sorted by newest first

## Implementation Notes
- Used Java 8 Streams a lot for filtering, mapping, and sorting.
- Parameterized tests cover all the “oops” cases with invalid inputs.
- Took care of edge cases like empty lists, null or blank values, and no matching products.
- Switched to `LocalDateTime` instead of `LocalDate` to properly track `createdDate` vs `modifiedDate`.

## Testing
All public methods are fully covered with **JUnit 5** unit tests, including both success and failure cases